### PR TITLE
Add app lifecycle callback

### DIFF
--- a/app/src/main/cpp/deps/raymob/CMakeLists.txt
+++ b/app/src/main/cpp/deps/raymob/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Define a library for raymoblib
-add_library(raymoblib STATIC helper.c sensor.c vibrator.c display.c soft_keyboard.c)
+add_library(raymoblib STATIC helper.c sensor.c vibrator.c display.c soft_keyboard.c callback.c)
 
 # Include headers directory for android_native_app_glue.c
 include_directories(${ANDROID_NDK}/sources/android/native_app_glue/)

--- a/app/src/main/cpp/deps/raymob/callback.c
+++ b/app/src/main/cpp/deps/raymob/callback.c
@@ -1,0 +1,52 @@
+#include "raymob.h"
+
+static Callback onPause = NULL;
+static Callback onResume = NULL;
+static Callback onDestroy = NULL;
+
+void SetOnResumeCallBack(Callback callback){
+    onResume = callback;
+}
+void SetOnPauseCallBack(Callback callback){
+    onPause = callback;
+}
+void SetOnDestroyCallBack(Callback callback){
+    onDestroy = callback;
+}
+
+JNIEXPORT void JNICALL
+custom_onAppResume(JNIEnv *env, jobject /* this */) {
+    if(onResume) onResume();
+}
+JNIEXPORT void JNICALL
+custom_onAppPause(JNIEnv *env, jobject /* this */) {
+    if(onPause) onPause();
+}
+JNIEXPORT void JNICALL
+custom_onAppDestroy(JNIEnv *env, jobject /* this */) {
+    if(onDestroy) onDestroy();
+}
+
+static JNINativeMethod methods[] = {
+        {"onAppResume", "()V", (void *)custom_onAppResume},
+        {"onAppPause", "()V", (void *)custom_onAppPause},
+        {"onAppDestroy", "()V", (void *)custom_onAppDestroy},
+};
+
+
+void InitCallBacks(){
+    jobject nativeLoaderInst = GetNativeLoaderInstance();
+
+    if (nativeLoaderInst != NULL) {
+        JNIEnv* env = AttachCurrentThread();
+
+        jclass nativeLoaderClass = (*env)->GetObjectClass(env, nativeLoaderInst);
+
+        (*env)->RegisterNatives(env, nativeLoaderClass, methods, sizeof(methods) / sizeof(methods[0]));
+
+        jfieldID fieldId = (*env)->GetFieldID(env, nativeLoaderClass, "initCallback", "Z");
+        (*env)->SetBooleanField(env, nativeLoaderInst, fieldId, JNI_TRUE);
+
+        DetachCurrentThread();
+    }
+}

--- a/app/src/main/cpp/deps/raymob/callback.c
+++ b/app/src/main/cpp/deps/raymob/callback.c
@@ -1,9 +1,13 @@
 #include "raymob.h"
 
+static Callback onStart = NULL;
 static Callback onPause = NULL;
 static Callback onResume = NULL;
 static Callback onDestroy = NULL;
 
+void SetOnStartCallBack(Callback callback){
+    onStart = callback;
+}
 void SetOnResumeCallBack(Callback callback){
     onResume = callback;
 }
@@ -14,6 +18,10 @@ void SetOnDestroyCallBack(Callback callback){
     onDestroy = callback;
 }
 
+JNIEXPORT void JNICALL
+custom_onAppStart(JNIEnv *env, jobject /* this */) {
+    if(onStart) onStart();
+}
 JNIEXPORT void JNICALL
 custom_onAppResume(JNIEnv *env, jobject /* this */) {
     if(onResume) onResume();
@@ -28,11 +36,11 @@ custom_onAppDestroy(JNIEnv *env, jobject /* this */) {
 }
 
 static JNINativeMethod methods[] = {
+        {"onAppStart", "()V", (void *)custom_onAppStart},
         {"onAppResume", "()V", (void *)custom_onAppResume},
         {"onAppPause", "()V", (void *)custom_onAppPause},
         {"onAppDestroy", "()V", (void *)custom_onAppDestroy},
 };
-
 
 void InitCallBacks(){
     jobject nativeLoaderInst = GetNativeLoaderInstance();

--- a/app/src/main/cpp/deps/raymob/raymob.h
+++ b/app/src/main/cpp/deps/raymob/raymob.h
@@ -240,8 +240,10 @@ void KeepScreenOn(bool keepOn);
 typedef void (*Callback)();
 
 void InitCallBacks(void);
+void SetOnStartCallBack(Callback callback);
 void SetOnResumeCallBack(Callback callback);
 void SetOnPauseCallBack(Callback callback);
+void SetOnDestroyCallBack(Callback callback);
 
 
 #if defined(__cplusplus)

--- a/app/src/main/cpp/deps/raymob/raymob.h
+++ b/app/src/main/cpp/deps/raymob/raymob.h
@@ -235,6 +235,15 @@ void SoftKeyboardEditText(char* text, unsigned int size);
  */
 void KeepScreenOn(bool keepOn);
 
+/* Callback functions */
+
+typedef void (*Callback)();
+
+void InitCallBacks(void);
+void SetOnResumeCallBack(Callback callback);
+void SetOnPauseCallBack(Callback callback);
+
+
 #if defined(__cplusplus)
 }
 #endif

--- a/app/src/main/cpp/deps/raymob/raymob.h
+++ b/app/src/main/cpp/deps/raymob/raymob.h
@@ -36,6 +36,10 @@ typedef enum {
     SENSOR_GYROSCOPE        = 1,
 } Sensor;
 
+/* Callback define */
+
+typedef void (*Callback)();
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -237,12 +241,37 @@ void KeepScreenOn(bool keepOn);
 
 /* Callback functions */
 
-typedef void (*Callback)();
-
+/**
+ * @brief Initializes all callback functions to their default states.
+ */
 void InitCallBacks(void);
+
+/**
+ * @brief Sets the callback function to be called when the application starts.
+ *
+ * @param callback The callback function to be executed on start.
+ */
 void SetOnStartCallBack(Callback callback);
+
+/**
+ * @brief Sets the callback function to be called when the application resumes.
+ *
+ * @param callback The callback function to be executed on resume.
+ */
 void SetOnResumeCallBack(Callback callback);
+
+/**
+ * @brief Sets the callback function to be called when the application pauses.
+ *
+ * @param callback The callback function to be executed on pause.
+ */
 void SetOnPauseCallBack(Callback callback);
+
+/**
+ * @brief Sets the callback function to be called when the application is destroyed.
+ *
+ * @param callback The callback function to be executed on destroy.
+ */
 void SetOnDestroyCallBack(Callback callback);
 
 

--- a/app/src/main/java/com/raylib/raymob/NativeLoader.java
+++ b/app/src/main/java/com/raylib/raymob/NativeLoader.java
@@ -60,6 +60,14 @@ public class NativeLoader extends NativeActivity {
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        if(initCallback) {
+            onAppStart();
+        }
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         if(initCallback) {
@@ -83,6 +91,7 @@ public class NativeLoader extends NativeActivity {
         }
     }
 
+    private native void onAppStart();
     private native void onAppResume();
     private native void onAppPause();
     private native void onAppDestroy();

--- a/app/src/main/java/com/raylib/raymob/NativeLoader.java
+++ b/app/src/main/java/com/raylib/raymob/NativeLoader.java
@@ -32,6 +32,7 @@ public class NativeLoader extends NativeActivity {
 
     public DisplayManager displayManager;
     public SoftKeyboard softKeyboard;
+    public boolean initCallback = false;
 
     // Loading method of your native application
     @Override
@@ -57,5 +58,33 @@ public class NativeLoader extends NativeActivity {
         softKeyboard.onKeyUpEvent(event);
         return super.onKeyDown(keyCode, event);
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if(initCallback) {
+            onAppResume();
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if(initCallback) {
+            onAppPause();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if(initCallback){
+            onAppDestroy();
+        }
+    }
+
+    private native void onAppResume();
+    private native void onAppPause();
+    private native void onAppDestroy();
 
 }


### PR DESCRIPTION
I have added this callbacks because raylib never exits using WindowShouldClose so I cant use this to save data when app closes and with this you don't need to save periodically.

Info: onStart never gets called, it gets called before you can register it and the next time the app is destroyed and it's not registered any more. Added for completion sake.

Info maybe warning: callbacks get called with another thread, but from my simple tests the main thread is paused so there shouldn't  be any race conditions to need to use mutex.

---
There is a simpler way without the Init function, you can just name a function with this signature pattern 
`Java_com_raylib_raymob_NativeLoader_onAppStart` but it doesn't get renamed if you change `app.application_id` so it just crashes because it wouldn't find the function.

