### PR TITLE
Change from OnDestroy to OnStop

### DIFF
--- a/app/src/main/cpp/deps/raymob/callback.c
+++ b/app/src/main/cpp/deps/raymob/callback.c
@@ -3,7 +3,7 @@
 static Callback onStart = NULL;
 static Callback onPause = NULL;
 static Callback onResume = NULL;
-static Callback onDestroy = NULL;
+static Callback onStop = NULL;
 
 void SetOnStartCallBack(Callback callback){
     onStart = callback;
@@ -14,32 +14,32 @@ void SetOnResumeCallBack(Callback callback){
 void SetOnPauseCallBack(Callback callback){
     onPause = callback;
 }
-void SetOnDestroyCallBack(Callback callback){
-    onDestroy = callback;
+void SetOnStopCallBack(Callback callback){
+    onStop = callback;
 }
 
 JNIEXPORT void JNICALL
-custom_onAppStart(JNIEnv *env, jobject /* this */) {
+custom_onAppStart(JNIEnv *env, jobject obj) {
     if(onStart) onStart();
 }
 JNIEXPORT void JNICALL
-custom_onAppResume(JNIEnv *env, jobject /* this */) {
+custom_onAppResume(JNIEnv *env, jobject obj) {
     if(onResume) onResume();
 }
 JNIEXPORT void JNICALL
-custom_onAppPause(JNIEnv *env, jobject /* this */) {
+custom_onAppPause(JNIEnv *env, jobject obj) {
     if(onPause) onPause();
 }
 JNIEXPORT void JNICALL
-custom_onAppDestroy(JNIEnv *env, jobject /* this */) {
-    if(onDestroy) onDestroy();
+custom_onAppStop(JNIEnv *env, jobject obj) {
+    if(onStop) onStop();
 }
 
 static JNINativeMethod methods[] = {
         {"onAppStart", "()V", (void *)custom_onAppStart},
         {"onAppResume", "()V", (void *)custom_onAppResume},
         {"onAppPause", "()V", (void *)custom_onAppPause},
-        {"onAppDestroy", "()V", (void *)custom_onAppDestroy},
+        {"onAppStop", "()V", (void *)custom_onAppStop},
 };
 
 void InitCallBacks(){

--- a/app/src/main/cpp/deps/raymob/raymob.h
+++ b/app/src/main/cpp/deps/raymob/raymob.h
@@ -268,11 +268,11 @@ void SetOnResumeCallBack(Callback callback);
 void SetOnPauseCallBack(Callback callback);
 
 /**
- * @brief Sets the callback function to be called when the application is destroyed.
+ * @brief Sets the callback function to be called when the application is stopped.
  *
  * @param callback The callback function to be executed on destroy.
  */
-void SetOnDestroyCallBack(Callback callback);
+void SetOnStopCallBack(Callback callback);
 
 
 #if defined(__cplusplus)

--- a/app/src/main/java/com/raylib/raymob/NativeLoader.java
+++ b/app/src/main/java/com/raylib/raymob/NativeLoader.java
@@ -84,16 +84,16 @@ public class NativeLoader extends NativeActivity {
     }
 
     @Override
-    protected void onDestroy() {
-        super.onDestroy();
+    protected void onStop() {
+        super.onStop();
         if(initCallback){
-            onAppDestroy();
+            onAppStop();
         }
     }
 
     private native void onAppStart();
     private native void onAppResume();
     private native void onAppPause();
-    private native void onAppDestroy();
+    private native void onAppStop();
 
 }


### PR DESCRIPTION

I figured out that i made a mistake in life cycle order, after OnPause is OnStop and not OnDestroy so I changed it. Plus on OnDestroy some times didn't work. 

---
And removed four warnings Omitting the parameter name in a function definition