### PR TITLE
Fixed crash in ClearLastSoftKey

### DIFF
--- a/app/src/main/cpp/deps/raymob/soft_keyboard.c
+++ b/app/src/main/cpp/deps/raymob/soft_keyboard.c
@@ -199,7 +199,7 @@ void ClearLastSoftKey(void)
 
         if (softKeyboard != NULL) {
             jclass softKeyboardClass = (*env)->GetObjectClass(env, softKeyboard);
-            jmethodID method = (*env)->GetMethodID(env, softKeyboardClass, "clearLastKeyEvent", "()V");
+            jmethodID method = (*env)->GetMethodID(env, softKeyboardClass, "clearLastEvent", "()V");
             (*env)->CallVoidMethod(env, softKeyboard, method);
         }
 


### PR DESCRIPTION
The `(*env)->CallVoidMethod` call in `ClearLastSoftKey` crashed because there is no `clearLastKeyEvent` function. The function is called `clearLastEvent` in the [java code](https://github.com/Bigfoot71/raymob/blob/master/app/src/main/java/com/raylib/raymob/SoftKeyboard.java#L68).