### PR TITLE
Downgraded Android Gradle plugin versions to 8.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.9.1' apply false
-    id 'com.android.library' version '8.9.1' apply false
+    id 'com.android.application' version '8.6.1' apply false
+    id 'com.android.library' version '8.6.1' apply false
 }


### PR DESCRIPTION
8.9.1 is incompatible with the project and causes a failure on Gradle build

`The project is using an incompatible version (AGP 8.9.1) of the Android Gradle plugin. Latest supported version is AGP 8.6.1`

Downgrading to 8.6.1 fixed the issue for me